### PR TITLE
Fix fail to execute because of undefined variable

### DIFF
--- a/bin/cloudflare-dns-update
+++ b/bin/cloudflare-dns-update
@@ -79,7 +79,7 @@ configuration_store.transaction do |configuration|
 	unless configuration[:domain]
 		puts "Getting list of domains for #{configuration[:zone]}..."
 		
-		cloudflare.rec_load_all(configuration[:zone])
+		result = cloudflare.rec_load_all(configuration[:zone])
 		
 		records = result['response']['recs']['objs']
 		


### PR DESCRIPTION
The Program is aborted because of reference of an uninitialized local variable.
