### PR TITLE
Fix backward compatibility

### DIFF
--- a/bin/cloudflare-dns-update
+++ b/bin/cloudflare-dns-update
@@ -76,7 +76,7 @@ configuration_store.transaction do |configuration|
 end
 
 configuration_store.transaction do |configuration|
-	unless configuration[:domains]
+	unless configuration[:domains] || configuration[:domain]
 		puts "Getting list of domains for #{configuration[:zone]}..."
 		
 		result = cloudflare.rec_load_all(configuration[:zone])


### PR DESCRIPTION
Sorry but changes in #2 are not  enough for backward compatibility.
You are going to be prompted after updating the gem, this means cron job does not work correctly.
I've also added `domain` key check.
