### PR TITLE
Update to use what seems to be the current way to log messages with Async

### DIFF
--- a/bin/cloudflare-dns-update
+++ b/bin/cloudflare-dns-update
@@ -27,6 +27,6 @@ begin
 rescue Interrupt
 	# Ignore.
 rescue => error
-	Async.logger.error(Cloudflare::DNS::Update::Command) {error}
+	Console.logger.error(Cloudflare::DNS::Update::Command) {error}
 	exit! 1
 end

--- a/lib/cloudflare/dns/update/command.rb
+++ b/lib/cloudflare/dns/update/command.rb
@@ -45,7 +45,7 @@ module Cloudflare::DNS::Update
 			end
 			
 			def logger
-				@logger ||= Async.logger
+				@logger ||= Console.logger
 			end
 			
 			def prompt


### PR DESCRIPTION
This gem didn't seem to work properly, and raised exceptions on calls to Async.logger. This patch changes that to Console.logger, which seems to be the modern way to do this.
